### PR TITLE
Integration test fixes in light of new Promise warnings

### DIFF
--- a/scripts/slack-github-issues.js
+++ b/scripts/slack-github-issues.js
@@ -42,10 +42,13 @@ function fileIssue(filer, response) {
       return issueUrl;
     })
     .catch(function(err) {
+      var result = err;
+
       if (err) {
-        response.reply(err.message || err);
+        result = err.message || err;
+        response.reply(result);
       }
-      return Promise.reject(err);
+      return result;
     });
 }
 

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -37,6 +37,7 @@ describe('Integration test', function() {
     apiStubServer = new ApiStubServer();
     process.env.HUBOT_SLACK_TOKEN = '<hubot-slack-api-token>';
     process.env.HUBOT_GITHUB_TOKEN = '<hubot-github-api-token>';
+    delete process.env.HUBOT_LOG_LEVEL;
     config = helpers.baseConfig();
     config.slackApiBaseUrl = apiStubServer.address() + '/slack/';
     config.githubApiBaseUrl = apiStubServer.address() + '/github/';

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -26,7 +26,7 @@ chai.should();
 chai.use(chaiAsPromised);
 
 describe('Integration test', function() {
-  var room, listenerCallbackPromise, logHelper, apiStubServer, config,
+  var room, listenerResult, logHelper, apiStubServer, config,
       apiServerDefaults, reactionAddedMessage, patchReactMethodOntoRoom,
       patchListenerCallbackAndImpl, sendReaction, initLogMessages,
       wrapInfoMessages, matchingRule = 'reactionName: evergreen_tree, ' +
@@ -158,7 +158,7 @@ describe('Integration test', function() {
     });
 
     listener.callback = function(response) {
-      listenerCallbackPromise = callback(response);
+      listenerResult = callback(response);
     };
   };
 
@@ -179,7 +179,7 @@ describe('Integration test', function() {
   sendReaction = function(reactionName) {
     logHelper.beginCapture();
     return room.user.react('mbland', reactionName)
-      .then(function() { return listenerCallbackPromise; })
+      .then(function() { return listenerResult; })
       .then(helpers.resolveNextTick, helpers.rejectNextTick)
       .then(logHelper.endCaptureResolve(), logHelper.endCaptureReject());
   };
@@ -240,8 +240,8 @@ describe('Integration test', function() {
 
     response.statusCode = 500;
     response.payload = payload;
-    return sendReaction(helpers.REACTION)
-      .should.be.rejectedWith(errorReply).then(function() {
+    return sendReaction(helpers.REACTION).should.become(errorReply)
+      .then(function() {
         var logMessages;
 
         room.messages.should.eql([
@@ -268,10 +268,9 @@ describe('Integration test', function() {
       response.payload = { message: 'should not happen' };
     });
 
-    return sendReaction('sad-face').should.be.rejectedWith(null)
-      .then(function() {
-        room.messages.should.eql([['mbland', 'sad-face']]);
-        logHelper.filteredMessages().should.eql(initLogMessages());
-      });
+    return sendReaction('sad-face').should.become(null).then(function() {
+      room.messages.should.eql([['mbland', 'sad-face']]);
+      logHelper.filteredMessages().should.eql(initLogMessages());
+    });
   });
 });


### PR DESCRIPTION
As discovered in 18F/hubot-slack-github-issues#51, the `UnhandledPromiseRejectionWarning` and `PromiseRejectionHandledWarning` warnings were apparently added in v6.6.0 (https://nodejs.org/en/blog/release/v6.6.0/); specifically it was added by nodejs/node#8223. See also:

  nodejs/node#6439
  nodejs/node#8217
  https://nodejs.org/dist/latest-v6.x/docs/api/process.html#process_event_unhandledrejection
  https://nodejs.org/dist/latest-v6.x/docs/api/process.html#process_event_rejectionhandled
  https://nodejs.org/dist/latest-v6.x/docs/api/process.html#process_event_warning

Test failures from `test/integration-test.js` after upgrading to Node v6.9.1 showed extra output such as:

```
  (node:39696) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): null
  (node:39696) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 2)
```

This was happening because `scripts/slack-github-issues.js` created a Hubot listener that returned a `Promise` so that the integration test could use `.should.be.rejectedWith` assertions. Rather than jump through hoops to quash the warnings, this change now causes the listener's `catch` handler to return the result of the rejected `Promise`, converting it to a fulfilled `Promise` in the process.

Since Hubot never used the result anyway, the only effect it has in production is to eliminate the warning messages. The tests now just check that the `Promise` returned by the listener callback is fulfilled with the expected error result, with practically no loss in clarity.

Also, there were test failures when I'd left `HUBOT_LOG_LEVEL=debug` set in the environment, which added `DEBUG` messages to the logging output. So there's also a commit to clear `HUBOT_LOG_LEVEL` in the test set up.