### PR TITLE
Updating dependencies to current repo name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = function(robot) {
-  require('slack-github-issues').loadHubotScript(robot);
+  require('slack-emoji-issues').loadHubotScript(robot);
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=4.2"
   },
   "dependencies": {
-    "slack-github-issues": "^1.0.0"
+    "slack-emoji-issues": "^1.0.0"
   },
   "peerDependencies": {
     "hubot": "^2.19.0",


### PR DESCRIPTION
https://github.com/mbland/slack-github-issues is forwarding to https://github.com/mbland/slack-emoji-issues . Thus i assume the repository name and npm package name of the dependency was updated. This change reflects this new situation...